### PR TITLE
Security Fix for Resources Downloaded over Insecure Protocol - huntr.dev

### DIFF
--- a/install
+++ b/install
@@ -29,7 +29,7 @@ if [ "$platform" != 'darwin' ] ; then
    #openal
    if [ ! -e "./openalsoft" ] ; then
       echo "Downloading OpenALSoft source"
-      `/usr/bin/curl -o "./openalsoft.tar.bz2" "http://kcat.strangesoft.net/openal-releases/openal-soft-1.12.854.tar.bz2"`
+      `/usr/bin/curl -o "./openalsoft.tar.bz2" "https://kcat.strangesoft.net/openal-releases/openal-soft-1.12.854.tar.bz2"`
       `tar -xvf "openalsoft.tar.bz2"`
       rm ./*.tar.bz2
       mv openal-soft*/ openalsoft
@@ -66,7 +66,7 @@ fi
 #SFML
 if [ ! -e "./sfml" ] ; then
    echo "Downloading SFML source"
-   `/usr/bin/svn checkout "http://sfml.svn.sourceforge.net/svnroot/sfml/tags/1.6" "sfml"`
+   `/usr/bin/svn checkout "https://sfml.svn.sourceforge.net/svnroot/sfml/tags/1.6" "sfml"`
    cd sfml
    
    


### PR DESCRIPTION
https://huntr.dev/users/mufeedvh has fixed the Resources Downloaded over Insecure Protocol vulnerability 🔨. mufeedvh has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?
           
Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/node-sfml/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/node-sfml/1/README.md

### User Comments:

### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-node-sfml

### ⚙️ Description *

The URL to import packages from was hardcoded to use the `http` version of the domains:
- `kcat.strangesoft.net`
- `www.mega-nerd.com`
- `sfml.svn.sourceforge.net`

### 💻 Technical Description *

The fix just simply changes the `http` version to `https` to mitigate MITM attacks.

### 🐛 Proof of Concept (PoC) *

`sfml` is Node v8 Bindings for SFML, this package are vulnerable to Man in the Middle (MitM) attacks due to downloading resources over an insecure protocol.

Without a secure connection, it is possible for an attacker to intercept this connection and alter the packages received. In serious cases, this may even lead to Remote Code Execution (RCE) on your host server.

**Ref:** https://www.huntr.dev/bounties/1-npm-node-sfml/

### 🔥 Proof of Fix (PoF) *

Changed all domains with SSL certificates to `https` in the `install` file.

**Although the domain `www.mega-nerd.com` doesn't have an SSL certificate making it not possible to use the `https` version of the domain.**

### 👍 User Acceptance Testing (UAT)

_No breaking changes._